### PR TITLE
Fix compilation errors

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -633,6 +633,7 @@ static inline uint64_t MUL(uint32_t a, uint32_t b) {
   return (uint64_t)a * (uint64_t)b;
 }
 
+#if 0  // Currently unused - kept for potential future use
 // From BearSSL. Performs a 32-bit->64-bit carryless/polynomial
 // long multiply.
 //
@@ -715,6 +716,7 @@ static std::pair<uint64_t, uint64_t> clmul_64(uint64_t x, uint64_t y) {
 
   return std::make_pair(xy0, xy1);
 }
+#endif  // Currently unused
 
 /* MMX */
 result_t test_mm_empty(const SSE2RVV_TEST_IMPL &impl, uint32_t iter) {


### PR DESCRIPTION
Wrap unused `clmul_32` and `clmul_64` functions in `#if 0` blocks to resolve compilation warnings.

These functions were defined but only referenced in commented-out test code, leading to "unused function" warnings. Wrapping them in `#if 0` preserves the code for potential future use while eliminating the warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac250c89-9be7-4d3d-9e4a-6e688922d83d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac250c89-9be7-4d3d-9e4a-6e688922d83d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

